### PR TITLE
Only execute 'Build, Verify and Package' job for draft PRs

### DIFF
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -9,6 +9,8 @@ on:
         default: true
         type: boolean
   pull_request:
+    # Also trigger on ready_for_review to catch the transition from draft to ready state.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
     paths:
@@ -141,6 +143,8 @@ jobs:
   deploy:
     name: Deploy to Azure
     needs: build-verify-package
+    # Only deploy if it's not a pull request or if the pull request is ready for review (not a draft) to avoid deploying from work-in-progress branches.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       id-token: write # Required to fetch an OIDC token for Azure authentication

--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ The pipeline consists of the following jobs:
 
   ![GitHub Actions Manual Trigger](images/github-actions-workflow-manual-trigger.png)
 
+For draft PRs, only the 'Build, Verify and Package' job is executed to avoid deploying from work-in-progress branches. When the PR is marked ready for review, the workflow will trigger and execute all jobs.
+
 > [!NOTE]
 > An Azure DevOps pipeline is also included in [.azdo/pipelines/azure-dev.yml](.azdo/pipelines/azure-dev.yml) that implements the same jobs as the GitHub Actions workflow.
 


### PR DESCRIPTION
Don’t deploy to Azure until the PR is ready for review. This gives time to process feedback from code review, including Copilot review, and prevents unnecessary deployments to Azure.