### PR TITLE
Use roleDefinitions function when assigning roles

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -19,4 +19,4 @@ services:
     host: function
     language: js # Logic Apps aren't natively supported by azd yet. By using js, the logic app will be zipped and deployed.
 requiredVersions:
-  azd: ">= 1.20.0" # azd version 1.20.0 or later is required because of the use of the onlyIfNotExists decorator.
+  azd: ">= 1.23.15" # azd version 1.23.15 or higher is required because we're using features from Bicep 0.42.1.

--- a/infra/modules/shared/assign-roles-to-principal.bicep
+++ b/infra/modules/shared/assign-roles-to-principal.bicep
@@ -19,7 +19,7 @@ param appInsightsName string
 // Variables
 //=============================================================================
 
-var monitoringMetricsPublisher string = '3913510d-42f4-4e42-8a64-420c390055eb' // Monitoring Metrics Publisher
+var monitoringMetricsPublisher string = 'Monitoring Metrics Publisher'
 
 //=============================================================================
 // Existing Resources
@@ -36,14 +36,11 @@ resource appInsights 'Microsoft.Insights/components@2020-02-02' existing = {
 // Assign role Application Insights to the principal
 
 resource assignAppInsightRolesToPrincipal 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(
-    principalId,
-    appInsights.id,
-    subscriptionResourceId('Microsoft.Authorization/roleDefinitions', monitoringMetricsPublisher)
-  )
+  name: guid(principalId, appInsights.id, roleDefinitions(monitoringMetricsPublisher).id)
   scope: appInsights
   properties: {
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', monitoringMetricsPublisher)
+    #disable-next-line use-resource-id-functions
+    roleDefinitionId: roleDefinitions(monitoringMetricsPublisher).id
     principalId: principalId
     principalType: principalType
   }

--- a/infra/modules/shared/assign-roles-to-principal.bicep
+++ b/infra/modules/shared/assign-roles-to-principal.bicep
@@ -19,7 +19,7 @@ param appInsightsName string
 // Variables
 //=============================================================================
 
-var monitoringMetricsPublisher string = 'Monitoring Metrics Publisher'
+var monitoringMetricsPublisherRoleName string = 'Monitoring Metrics Publisher'
 
 //=============================================================================
 // Existing Resources
@@ -36,11 +36,11 @@ resource appInsights 'Microsoft.Insights/components@2020-02-02' existing = {
 // Assign role Application Insights to the principal
 
 resource assignAppInsightRolesToPrincipal 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(principalId, appInsights.id, roleDefinitions(monitoringMetricsPublisher).id)
+  name: guid(principalId, appInsights.id, roleDefinitions(monitoringMetricsPublisherRoleName).id)
   scope: appInsights
   properties: {
     #disable-next-line use-resource-id-functions
-    roleDefinitionId: roleDefinitions(monitoringMetricsPublisher).id
+    roleDefinitionId: roleDefinitions(monitoringMetricsPublisherRoleName).id
     principalId: principalId
     principalType: principalType
   }


### PR DESCRIPTION
Had to suppress `use-resource-id-functions` linter rule because using `roleDefinitions` doesn't (yet) comply with this rule.